### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ setup(
     keywords=[ 'pytest', 'py.test', 'remotedata', 'openfiles', 'doctestplus' ],
     python_requires='>=2.7',
     install_requires=[
-        'pytest>=2.8.0',
+        'pytest>=3.1.0',
         'pytest-doctestplus',
-        'pytest-remotedata',
+        'pytest-remotedata>=0.2.0',
         'pytest-openfiles'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         'pytest>=3.1.0',
         'pytest-doctestplus',
         'pytest-remotedata>=0.2.0',
-        'pytest-openfiles'
+        'pytest-openfiles',
+        'pytest-mpl',
+        'pytest-arraydiff'
     ]
 )


### PR DESCRIPTION
This fixes #4 and fixes #5. The dependency on `pytest` was upgraded to 3.1, since this is what `pytest-remotedata` depends on now.