### PR TITLE
Explicitly pin pytest-arraydiff to >=0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.2.2 (unreleased)
 ==================
 
+- Explicitly pin ``pytest-arraydiff`` to version >= 0.1. [#10]
+
 0.2.1 (2017-12-08)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
         'pytest-openfiles>=0.2.0',
         # Do not include as dependency until CI issues can be worked out
         #'pytest-mpl',
-        'pytest-arraydiff'
+        'pytest-arraydiff>=0.1'
     ]
 )


### PR DESCRIPTION
This closes #9.