### PR TITLE
Moved header plugin from astropy core to here

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
         - PYTEST_VERSION=4
         - PYTEST_COMMAND='pytest'
         - NUMPY_VERSION=stable
+        - CONDA_DEPENDENCIES='astropy'
 
     matrix:
         - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
+
+os:
+    - linux
+    - windows
+
+# Use Travis' container-based architecture
+sudo: false
+
+env:
+    global:
+        # The following versions are the 'default' for tests, unless
+        # overidden underneath. They are defined here in order to save having
+        # to repeat them for all configurations.
+        - PYTHON_VERSION=3.7
+        - PYTEST_VERSION=4
+        - PYTEST_COMMAND='pytest'
+        - NUMPY_VERSION=stable
+
+    matrix:
+        - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'
+        - PYTHON_VERSION=2.7
+        - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
+        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.8
+        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.9
+        - PYTHON_VERSION=3.7
+
+matrix:
+    include:
+        # Try a run on OSX with latest versions of python and pytest
+        - os: osx
+          env: PYTHON_VERSION=3.7
+
+        # Try a run against latest pytest
+        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
+
+install:
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
+    - pip install -e .
+
+script:
+   - $PYTEST_COMMAND

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,9 @@
 pytest-astropy
 ==============
 
-This is a meta-package that pulls in the dependencies that are used by
-`astropy`_ and some `affiliated packages`_ for testing. It can also be used for
+This is a package that pulls in the dependencies that are used by
+`astropy`_ and some `affiliated packages`_ for testing, and also provides
+additional project-specific plugins. It can also be used for
 testing packages that are not affiliated with the Astropy project.
 
 .. _astropy: https://astropy.org/en/latest/
@@ -47,6 +48,132 @@ repository::
 In either case, the plugin will automatically be registered for use with
 ``pytest``.
 
+Header plugin
+-------------
+
+One of the plugins provided by this package makes it easy to include a header
+with diagnostic information before running the tests, e.g.::
+
+    Running tests in astropy.
+
+    Date: 2019-09-02T23:33:43
+
+    Platform: Darwin-18.7.0-x86_64-i386-64bit
+
+    Executable: /Users/tom/python/dev/bin/python3.7
+
+    Full Python Version:
+    3.7.4 (v3.7.4:e09359112e, Jul  8 2019, 14:54:52)
+    [Clang 6.0 (clang-600.0.57)]
+
+    encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
+    byteorder: little
+    float info: dig: 15, mant_dig: 15
+
+    Package versions:
+    numpy: 1.16.4
+    scipy: 1.3.0
+    matplotlib: 3.1.1
+    h5py: 2.9.0
+    pandas: 0.24.2
+    astropy: 4.0.dev25634
+
+    Using Astropy options: remote_data: none.
+
+The most robust way to enable the plugin in a way that will work regardless of
+how the tests are run (e.g. via ``python setup.py test``, ``pytest``, or
+``package.test()``) is to add the following to a ``conftest.py`` file that is
+inside your package::
+
+    def pytest_configure(config):
+        config.option.astropy_header = True
+
+
+By default, a few packages will be shown, but you may want to customize how the
+packages appear. As for enabling the plugin, the most robust way to do this to
+be compatible with different astropy versions is via the ``conftest.py`` file::
+
+    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+    def pytest_configure(config):
+        config.option.astropy_header = True
+        PYTEST_HEADER_MODULES.pop('Pandas')
+        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+
+The key to ``PYTEST_HEADER_MODULES`` should be the name that will be displayed
+in the header, and the value should be the name of the Python module.
+
+Migrating from the astropy header plugin to pytest-astropy
+----------------------------------------------------------
+
+Before the v4.0 release of the core astropy package, the plugin that handles the
+header of the testing output described above lived in
+``astropy.tests.plugins.display``. A few steps are now needed to update packages
+to make sure that only the pytest-astropy version is used instead. These should
+be done in addition to the configuration mentioned in the previous section.
+
+First, you should be able to significantly simplify the ``conftest.py`` file by
+replacing e.g.::
+
+    from astropy.version import version as astropy_version
+    if astropy_version < '3.0':
+        # With older versions of Astropy, we actually need to import the pytest
+        # plugins themselves in order to make them discoverable by pytest.
+        from astropy.tests.pytest_plugins import *
+    else:
+        # As of Astropy 3.0, the pytest plugins provided by Astropy are
+        # automatically made available when Astropy is installed. This means it's
+        # not necessary to import them here, but we still need to import global
+        # variables that are used for configuration.
+        from astropy.tests.plugins.display import (pytest_report_header,
+                                                   PYTEST_HEADER_MODULES,
+                                                   TESTED_VERSIONS)
+
+    # Customize the following lines to add/remove entries from
+    # the list of packages for which version numbers are displayed when running
+    # the tests. Making it pass for KeyError is essential in some cases when
+    # the package uses other astropy affiliated packages.
+    try:
+        PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+        del PYTEST_HEADER_MODULES['h5py']
+    except KeyError:
+        pass
+
+    # This is to figure out the package version, rather than
+    # using Astropy's
+    from .version import version, astropy_helpers_version
+
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version
+    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
+
+with e.g.::
+
+    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+    def pytest_configure(config):
+
+        config.option.astropy_header = True
+
+        PYTEST_HEADER_MODULES.pop('Pandas')
+        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+
+        from .version import version, astropy_helpers_version
+        packagename = os.path.basename(os.path.dirname(__file__))
+        TESTED_VERSIONS[packagename] = version
+        TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
+
+Note that while you will need to use a recent version of pytest-astropy for this
+to work, it should work with Astropy 2.0 onwards without requiring all the
+``try...except`` for imports.
+
+Next check all of your ``conftest.py`` files and be sure to remove the old
+plugin from lists such as::
+
+    pytest_plugins = [
+      'astropy.tests.plugins.display',
+    ]
+
 Development Status
 ------------------
 
@@ -56,5 +183,6 @@ Questions, bug reports, and feature requests can be submitted on `github`_.
 
 License
 -------
+
 This package is licensed under a 3-clause BSD style license - see the
 ``LICENSE.rst`` file.

--- a/README.rst
+++ b/README.rst
@@ -149,13 +149,21 @@ replacing e.g.::
 
 with e.g.::
 
-    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    import os
+
+    from astropy.version import version as astropy_version
+    if astropy_version < '3.0':
+        from astropy.tests.pytest_plugins import *
+        del pytest_report_header
+    else:
+        from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
 
     def pytest_configure(config):
 
         config.option.astropy_header = True
 
-        PYTEST_HEADER_MODULES.pop('Pandas')
+        PYTEST_HEADER_MODULES.pop('Pandas', None)
         PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
 
         from .version import version, astropy_helpers_version

--- a/pytest_astropy/display.py
+++ b/pytest_astropy/display.py
@@ -1,0 +1,141 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This plugin provides customization of the header displayed by pytest for
+reporting purposes.
+"""
+
+import os
+import sys
+import datetime
+import locale
+import math
+from collections import OrderedDict
+
+from astropy.tests.helper import ignore_warnings
+from astropy.utils.introspection import resolve_name
+
+
+PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
+                                     ('Scipy', 'scipy'),
+                                     ('Matplotlib', 'matplotlib'),
+                                     ('h5py', 'h5py'),
+                                     ('Pandas', 'pandas')])
+
+# This always returns with Astropy's version
+from astropy import __version__
+TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
+
+
+def pytest_report_header(config):
+
+    try:
+        stdoutencoding = sys.stdout.encoding or 'ascii'
+    except AttributeError:
+        stdoutencoding = 'ascii'
+
+    args = config.args
+
+    # TESTED_VERSIONS can contain the affiliated package version, too
+    if len(TESTED_VERSIONS) > 1:
+        for pkg, version in TESTED_VERSIONS.items():
+            if pkg not in ['Astropy', 'astropy_helpers']:
+                s = "\nRunning tests with {} version {}.\n".format(
+                    pkg, version)
+    else:
+        s = "\nRunning tests with Astropy version {}.\n".format(
+            TESTED_VERSIONS['Astropy'])
+
+    # Per https://github.com/astropy/astropy/pull/4204, strip the rootdir from
+    # each directory argument
+    if hasattr(config, 'rootdir'):
+        rootdir = str(config.rootdir)
+        if not rootdir.endswith(os.sep):
+            rootdir += os.sep
+
+        dirs = [arg[len(rootdir):] if arg.startswith(rootdir) else arg
+                for arg in args]
+    else:
+        dirs = args
+
+    s += "Running tests in {}.\n\n".format(" ".join(dirs))
+
+    s += "Date: {}\n\n".format(datetime.datetime.now().isoformat()[:19])
+
+    from platform import platform
+    plat = platform()
+    if isinstance(plat, bytes):
+        plat = plat.decode(stdoutencoding, 'replace')
+    s += f"Platform: {plat}\n\n"
+    s += f"Executable: {sys.executable}\n\n"
+    s += f"Full Python Version: \n{sys.version}\n\n"
+
+    s += "encodings: sys: {}, locale: {}, filesystem: {}".format(
+        sys.getdefaultencoding(),
+        locale.getpreferredencoding(),
+        sys.getfilesystemencoding())
+    s += '\n'
+
+    s += f"byteorder: {sys.byteorder}\n"
+    s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
+        sys.float_info)
+
+    for module_display, module_name in PYTEST_HEADER_MODULES.items():
+        try:
+            with ignore_warnings(DeprecationWarning):
+                module = resolve_name(module_name)
+        except ImportError:
+            s += f"{module_display}: not available\n"
+        else:
+            try:
+                version = module.__version__
+            except AttributeError:
+                version = 'unknown (no __version__ attribute)'
+            s += f"{module_display}: {version}\n"
+
+    # Helpers version
+    if 'astropy_helpers' in TESTED_VERSIONS:
+        astropy_helpers_version = TESTED_VERSIONS['astropy_helpers']
+    else:
+        try:
+            from astropy.version import astropy_helpers_version
+        except ImportError:
+            astropy_helpers_version = None
+
+    if astropy_helpers_version:
+        s += f"astropy_helpers: {astropy_helpers_version}\n"
+
+    special_opts = ["remote_data", "pep8"]
+    opts = []
+    for op in special_opts:
+        op_value = getattr(config.option, op, None)
+        if op_value:
+            if isinstance(op_value, str):
+                op = ': '.join((op, op_value))
+            opts.append(op)
+    if opts:
+        s += "Using Astropy options: {}.\n".format(", ".join(opts))
+
+    return s
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Output a warning to IPython users in case any tests failed."""
+
+    try:
+        get_ipython()
+    except NameError:
+        return
+
+    if not terminalreporter.stats.get('failed'):
+        # Only issue the warning when there are actually failures
+        return
+
+    terminalreporter.ensure_newline()
+    terminalreporter.write_line(
+        'Some tests are known to fail when run from the IPython prompt; '
+        'especially, but not limited to tests involving logging and warning '
+        'handling.  Unless you are certain as to the cause of the failure, '
+        'please check that the failure occurs outside IPython as well.  See '
+        'http://docs.astropy.org/en/stable/known_issues.html#failing-logging-'
+        'tests-when-running-the-tests-in-ipython for more information.',
+        yellow=True, bold=True)

--- a/pytest_astropy/display.py
+++ b/pytest_astropy/display.py
@@ -11,19 +11,27 @@ import locale
 import math
 from collections import OrderedDict
 
+from astropy import __version__ as astropy_version
 from astropy.tests.helper import ignore_warnings
 from astropy.utils.introspection import resolve_name
 
-
-PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
-                                     ('Scipy', 'scipy'),
-                                     ('Matplotlib', 'matplotlib'),
-                                     ('h5py', 'h5py'),
-                                     ('Pandas', 'pandas')])
-
-# This always returns with Astropy's version
-from astropy import __version__
-TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
+# If using a version of astropy that has the display plugin, we make sure that
+# we use those variables for listing the packages, in case we choose to let
+# that plugin handle things below (which we do if that plugin is active).
+try:
+    try:
+        from astropy.tests.plugins.display import (PYTEST_HEADER_MODULES,
+                                                   TESTED_VERSIONS)
+    except ImportError:
+        from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
+                                                  TESTED_VERSIONS)
+except ImportError:
+    PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
+                                        ('Scipy', 'scipy'),
+                                        ('Matplotlib', 'matplotlib'),
+                                        ('h5py', 'h5py'),
+                                        ('Pandas', 'pandas')])
+    TESTED_VERSIONS = OrderedDict([('Astropy', astropy_version)])
 
 
 def pytest_addoption(parser):
@@ -39,6 +47,11 @@ def pytest_addoption(parser):
 
 
 def pytest_report_header(config):
+
+    # If the astropy display plugin is registered, we stop now and let it
+    # handle the header.
+    if config.pluginmanager.hasplugin('astropy.tests.plugins.display'):
+        return
 
     if not config.getoption("astropy_header") and not config.getini("astropy_header"):
         return

--- a/pytest_astropy/display.py
+++ b/pytest_astropy/display.py
@@ -26,7 +26,36 @@ from astropy import __version__
 TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup("astropy header options")
+    group.addoption('--astropy-header', action='store_true',
+                    help="Show the pytest-astropy header")
+    group.addoption('--astropy-header-packages', default=None,
+                    help="Comma-separated list of packages to include in the header")
+    parser.addini('astropy_header', type="bool",
+                  help="Show the pytest-astropy header")
+    parser.addini('astropy_header_packages', type='linelist',
+                  help="Comma-separated list of packages to include in the header")
+
+
 def pytest_report_header(config):
+
+    if not config.getoption("astropy_header") and not config.getini("astropy_header"):
+        return
+
+    astropy_header_packages_option = config.getoption("astropy_header_packages")
+    astropy_header_packages_ini = config.getini("astropy_header_packages")
+
+    if astropy_header_packages_option is not None:
+        if isinstance(astropy_header_packages_option, str):
+            astropy_header_packages_option = [x.strip() for x in astropy_header_packages_option.split(',')]
+        packages_to_display = OrderedDict([(x, x) for x in astropy_header_packages_option])
+    elif len(astropy_header_packages_ini) > 0:
+        if len(astropy_header_packages_ini) == 1:
+            astropy_header_packages_ini = [x.strip() for x in astropy_header_packages_ini[0].split(',')]
+        packages_to_display = OrderedDict([(x, x) for x in astropy_header_packages_ini])
+    else:
+        packages_to_display = PYTEST_HEADER_MODULES
 
     try:
         stdoutencoding = sys.stdout.encoding or 'ascii'
@@ -79,7 +108,9 @@ def pytest_report_header(config):
     s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
         sys.float_info)
 
-    for module_display, module_name in PYTEST_HEADER_MODULES.items():
+    s += f"Package versions: \n"
+
+    for module_display, module_name in packages_to_display.items():
         try:
             with ignore_warnings(DeprecationWarning):
                 module = resolve_name(module_name)
@@ -102,7 +133,9 @@ def pytest_report_header(config):
             astropy_helpers_version = None
 
     if astropy_helpers_version:
-        s += f"astropy_helpers: {astropy_helpers_version}\n"
+        s += f"astropy-helpers: {astropy_helpers_version}\n"
+
+    s += "\n"
 
     special_opts = ["remote_data", "pep8"]
     opts = []

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,10 @@ setup(
         # Do not include as dependency until CI issues can be worked out
         #'pytest-mpl',
         'pytest-arraydiff>=0.1'
-    ]
+    ],
+    entry_points={
+        'pytest11': [
+            'pytest_astropy_header = pytest_astropy.display',
+        ],
+    }
 )

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,201 @@
+import pytest
+
+import numpy
+import pandas
+import skimage
+
+NUMPY_VERSION = numpy.__version__
+PANDAS_VERSION = pandas.__version__
+SKIMAGE_VERSION = skimage.__version__
+
+pytest_plugins = ['pytester']
+
+
+def extract_package_version_lines(output):
+    lines = []
+    in_section = False
+    for line in output.splitlines():
+        if line.strip() == 'Package versions:':
+            in_section = True
+        elif in_section:
+            if line.strip() == "":
+                break
+            else:
+                lines.append(line)
+    return lines
+
+
+def test_default(testdir, capsys):
+    testdir.inline_run()
+    out, err = capsys.readouterr()
+    assert 'Package versions:' not in out
+
+
+@pytest.mark.parametrize('method', ['cli', 'ini', 'conftest'])
+def test_enabled(testdir, capsys, method):
+    if method == 'cli':
+        testdir.inline_run("--astropy-header")
+    elif method == 'ini':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+        """)
+        testdir.inline_run()
+    elif method == 'conftest':
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                config.option.astropy_header = True
+        """)
+    testdir.inline_run()
+    out, err = capsys.readouterr()
+    lines = extract_package_version_lines(out)
+    assert len(lines) == 6
+    assert lines[0].startswith('Numpy: ')
+    assert lines[1].startswith('Scipy: ')
+    assert lines[2].startswith('Matplotlib: ')
+    assert lines[3].startswith('h5py: ')
+    assert lines[4].startswith('Pandas: ')
+    assert lines[5].startswith('astropy-helpers: ')
+
+
+@pytest.mark.parametrize('method', ['ini', 'conftest'])
+def test_explicit_disable(testdir, capsys, method):
+    if method == 'ini':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = no
+        """)
+        testdir.inline_run()
+    elif method == 'conftest':
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                config.option.astropy_header = False
+        """)
+    testdir.inline_run()
+    out, err = capsys.readouterr()
+    assert 'Package versions:' not in out
+
+
+@pytest.mark.parametrize('method', ['cli', 'ini', 'ini_list', 'conftest'])
+def test_override_package_single(testdir, capsys, method):
+    if method == 'cli':
+        testdir.inline_run("--astropy-header", "--astropy-header-packages=numpy")
+    elif method == 'ini':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages = numpy
+        """)
+        testdir.inline_run()
+    elif method == 'ini_list':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages =
+                numpy
+        """)
+        testdir.inline_run()
+    elif method == 'conftest':
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                config.option.astropy_header = True
+                config.option.astropy_header_packages = ['numpy']
+        """)
+        testdir.inline_run()
+    out, err = capsys.readouterr()
+    lines = extract_package_version_lines(out)
+    assert len(lines) == 2
+    assert lines[0] == f'numpy: {NUMPY_VERSION}'
+    assert lines[1].startswith('astropy-helpers: ')
+
+
+@pytest.mark.parametrize('method', ['cli', 'ini', 'ini_list', 'conftest'])
+def test_override_package_multiple(testdir, capsys, method):
+    if method == 'cli':
+        testdir.inline_run("--astropy-header", "--astropy-header-packages=numpy,pandas")
+    elif method == 'ini':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages = numpy, pandas
+        """)
+        testdir.inline_run()
+    elif method == 'ini_list':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages =
+                numpy
+                pandas
+        """)
+        testdir.inline_run()
+    elif method == 'conftest':
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                config.option.astropy_header = True
+                config.option.astropy_header_packages = ['numpy', 'pandas']
+        """)
+        testdir.inline_run()
+    out, err = capsys.readouterr()
+    print(out)
+    lines = extract_package_version_lines(out)
+    assert len(lines) == 3
+    assert lines[0] == f'numpy: {NUMPY_VERSION}'
+    assert lines[1] == f'pandas: {PANDAS_VERSION}'
+    assert lines[2].startswith('astropy-helpers: ')
+
+
+@pytest.mark.parametrize('method', ['cli', 'ini', 'ini_list', 'conftest'])
+def test_nonexistent(testdir, capsys, method):
+    if method == 'cli':
+        testdir.inline_run("--astropy-header", "--astropy-header-packages=apackagethatdoesnotexist")
+    elif method == 'ini':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages = apackagethatdoesnotexist
+        """)
+        testdir.inline_run()
+    elif method == 'ini_list':
+        testdir.makeini("""
+            [pytest]
+            astropy_header = yes
+            astropy_header_packages =
+                apackagethatdoesnotexist
+        """)
+        testdir.inline_run()
+    elif method == 'conftest':
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                config.option.astropy_header = True
+                config.option.astropy_header_packages = ['apackagethatdoesnotexist']
+        """)
+        testdir.inline_run()
+    out, err = capsys.readouterr()
+    lines = extract_package_version_lines(out)
+    assert len(lines) == 2
+    assert lines[0] == f'apackagethatdoesnotexist: not available'
+    assert lines[1].startswith('astropy-helpers: ')
+
+
+def test_modify_in_conftest(testdir, capsys):
+    testdir.makeconftest("""
+    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+    def pytest_configure(config):
+        config.option.astropy_header = True
+        PYTEST_HEADER_MODULES.pop('Pandas')
+        PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+        TESTED_VERSIONS['fakepackage'] = '1.0.2'
+    """)
+    testdir.inline_run()
+    out, err = capsys.readouterr()
+    lines = extract_package_version_lines(out)
+    assert len(lines) == 6
+    assert lines[0].startswith('Numpy: ')
+    assert lines[1].startswith('Scipy: ')
+    assert lines[2].startswith('Matplotlib: ')
+    assert lines[3].startswith('h5py: ')
+    assert lines[4].startswith('scikit-image: ')
+    assert lines[5].startswith('astropy-helpers: ')
+    assert 'Running tests with fakepackage version 1.0.2' in out

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -101,7 +101,7 @@ def test_override_package_single(testdir, capsys, method):
     out, err = capsys.readouterr()
     lines = extract_package_version_lines(out)
     assert len(lines) == 2
-    assert lines[0] == f'numpy: {NUMPY_VERSION}'
+    assert lines[0] == 'numpy: {NUMPY_VERSION}'.format(NUMPY_VERSION=NUMPY_VERSION)
     assert lines[1].startswith('astropy-helpers: ')
 
 
@@ -136,7 +136,7 @@ def test_override_package_multiple(testdir, capsys, method):
     print(out)
     lines = extract_package_version_lines(out)
     assert len(lines) == 3
-    assert lines[0] == f'numpy: {NUMPY_VERSION}'
+    assert lines[0] == 'numpy: {NUMPY_VERSION}'.format(NUMPY_VERSION=NUMPY_VERSION)
     assert lines[1].startswith('pandas')
     assert lines[2].startswith('astropy-helpers: ')
 
@@ -170,7 +170,7 @@ def test_nonexistent(testdir, capsys, method):
     out, err = capsys.readouterr()
     lines = extract_package_version_lines(out)
     assert len(lines) == 2
-    assert lines[0] == f'apackagethatdoesnotexist: not available'
+    assert lines[0] == 'apackagethatdoesnotexist: not available'
     assert lines[1].startswith('astropy-helpers: ')
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,12 +1,8 @@
 import pytest
 
 import numpy
-import pandas
-import skimage
 
 NUMPY_VERSION = numpy.__version__
-PANDAS_VERSION = pandas.__version__
-SKIMAGE_VERSION = skimage.__version__
 
 pytest_plugins = ['pytester']
 
@@ -141,7 +137,7 @@ def test_override_package_multiple(testdir, capsys, method):
     lines = extract_package_version_lines(out)
     assert len(lines) == 3
     assert lines[0] == f'numpy: {NUMPY_VERSION}'
-    assert lines[1] == f'pandas: {PANDAS_VERSION}'
+    assert lines[1].startswith('pandas')
     assert lines[2].startswith('astropy-helpers: ')
 
 


### PR DESCRIPTION
This moves the last remaining plugin from astropy core to here, and fixes https://github.com/astropy/pytest-astropy/issues/15.

**DO NOT MERGE:** please don't merge yet as if people are in favor of this I will fix up the commits to include the history of commits on this plugin first. I'm also still working on this as there are some issues to resolve, so marking this as a Draft PR.

### Benefits to migrating

The main motivation for migrating is that this will make it easier in future to make improvements to the plugin without having to rely on the astropy release cycle. It also should simplify configuration for the plugin in third party packages. This was the last plugin that still lived in astropy core.

### Migration for packages

As usual, we have to be careful to think of all testing scenarios when moving a plugin, to minimize pain. I've therefore included a section in the README on migrating to this new plugin. Note that the new plugin is essentially opt-in - packages need to take action to switch to the new one, which is necessary to avoid people seeing the astropy header for unrelated packages. See the README for more details.

If packages don't do anything, things will continue to work except that a deprecation warning will be raised with astropy 4.0 (and until we decide to break things). So this should be a gentle transition :crossed_fingers: 

### Impact for core package

I will shortly open a companion PR for the core package switching over to the new plugin, and we can merge that PR once we have a new release of pytest-astropy out.

### Impact for other packages

For third-party packages, there are several cases to consider. I'm assuming packages follow the migration instructions in the README.

When the plugin is used and astropy<4 is installed, the ``PYTEST_HEADER_MODULES`` and
``TESTED_VERSIONS`` variables are actually shared with astropy. The new plugin here is smart enough to detect if the original plugin is enabled, and if so, the one here will do nothing and the astropy one will work as expected since the variables are shared. For astropy 2.0 the display header was not a real plugin so we can disable it as described using ``del pytest_report_header`` as described in the migration guide.

With astropy >4 this should work as expected since there is now only one plugin, the one in this package.

Here's an example with ccdproc including the changes described in the migration docs here. so with ``conftest.py`` set to:

```python
import os

from .tests.pytest_fixtures import *

from astropy.version import version as astropy_version
if astropy_version < '3.0':
    from astropy.tests.pytest_plugins import *
    del pytest_report_header
else:
    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS


def pytest_configure(config):

    config.option.astropy_header = True

    PYTEST_HEADER_MODULES.pop('h5py', None)
    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
    PYTEST_HEADER_MODULES['astroscrappy'] = 'astroscrappy'
    PYTEST_HEADER_MODULES['reproject'] = 'reproject'

    from .version import version, astropy_helpers_version
    packagename = os.path.basename(os.path.dirname(__file__))
    TESTED_VERSIONS[packagename] = version
    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
```

**Running the tests with python setup.py test**

_With astropy 2.0.15:_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T16:13:55

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy 3.2.1:_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T15:57:42

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy_helpers: 3.2.1
Using Astropy options: remote_data: none.
```

_With astropy dev (after plugin removal, see https://github.com/astropy/astropy/pull/9214):_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T16:48:17

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```

**Running the tests with pytest**

_With astropy 2.0.15:_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:18:58

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```

_With astropy 3.2.1:_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T15:59:06

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy dev (after plugin removal, see https://github.com/astropy/astropy/pull/9214):_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:49:22

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

**Running the tests with package.test()**

_With astropy 2.0.14:_

```
In [2]: ccdproc.test()                                                                                                                                     
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:12:57

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy 3.2.1:_

```
In [2]: ccdproc.test()                                                                                                                                     
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:00:41

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy_helpers: 3.2.1
Using Astropy options: remote_data: none.
```

_With astropy dev (after plugin removal, see https://github.com/astropy/astropy/pull/9214):_

```
In [2]: ccdproc.test()                                                                                                                                     
WARNING: AstropyDeprecationWarning: The astropy.tests.plugins.display plugin has been deprecated. See the pytest-astropy documentation for information on migrating to using pytest-astropy to customize the pytest header. [astropy.tests.plugins.display]
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:49:49

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: not available
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```

### Open questions

* Do we agree that this should live here? (consistent with sphinx-astropy being a meta-package **and** astropy-specific things). Or do we think it should be a separate plugin?