### PR TITLE
Add more plugins and refactor infrastructure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 0.8.0 (unreleased)
 ==================
 
-- Added ``pytest-mpl``, ``pytest-filter-subpackage`` and ``pytest-cov``
-  as dependencies. [#29]
+- Added ``pytest-filter-subpackage`` and ``pytest-cov`` as dependencies. [#29]
+
+- Dropped support for Python 2.7 and 3.5. [#29]
+
+- Require Hypothesis 5.1 or later. [#29]
 
 0.7.0 (2019-12-10)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.8.0 (unreleased)
+==================
+
+- Added ``pytest-mpl``, ``pytest-filter-subpackage`` and ``pytest-cov``
+  as dependencies. [#29]
+
 0.7.0 (2019-12-10)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,6 @@ The following dependencies are installed by this package:
   inadvertently left open at the end of unit tests
 * `pytest-arraydiff`_, a ``pytest`` plugin that enables the generation and
   comparison of data arrays produced during unit tests
-* `pytest-astropy-header`_, a ``pytest`` plugin that adds additional diagnostic
-  information to the header of the test output.
 * `pytest-filter-subpackage`_, a ``pytest`` plugin that adds a ``-P`` option to
   pytest to filter by sub-package.
 * `pytest-mpl`_, a ``pytest`` plugin used for pixel-by-pixel testing of images
@@ -39,7 +37,6 @@ The following dependencies are installed by this package:
 .. _pytest-doctestplus: https://github.com/astropy/pytest-doctestplus
 .. _pytest-openfiles: https://github.com/astropy/pytest-openfiles
 .. _pytest-arraydiff: https://github.com/astropy/pytest-arraydiff
-.. _pytest-astropy-header: https://github.com/astropy/pytest-astropy-header
 .. _pytest-filter-subpackage: https://github.com/astropy/pytest-filter-subpackage
 .. _pytest-mpl: https://github.com/matplotlib/pytest-mpl
 .. _pytest-cov: https://github.com/pytest-dev/pytest-cov

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,13 @@ The following dependencies are installed by this package:
   inadvertently left open at the end of unit tests
 * `pytest-arraydiff`_, a ``pytest`` plugin that enables the generation and
   comparison of data arrays produced during unit tests
+* `pytest-astropy-header`_, a ``pytest`` plugin that adds additional diagnostic
+  information to the header of the test output.
+* `pytest-filter-subpackage`_, a ``pytest`` plugin that adds a ``-P`` option to
+  pytest to filter by sub-package.
+* `pytest-mpl`_, a ``pytest`` plugin used for pixel-by-pixel testing of images
+  generated from tests.
+* `pytest-cov`_, a ``pytest`` plugin to measure test coverage.
 * `hypothesis`_, a Python library for property based testing.
 
 .. _pytest: https://doc.pytest.org
@@ -31,7 +38,11 @@ The following dependencies are installed by this package:
 .. _pytest-remotedata: https://github.com/astropy/pytest-remotedata
 .. _pytest-doctestplus: https://github.com/astropy/pytest-doctestplus
 .. _pytest-openfiles: https://github.com/astropy/pytest-openfiles
-.. _pytest-arraydiff: https://github.com/astrofrog/pytest-arraydiff
+.. _pytest-arraydiff: https://github.com/astropy/pytest-arraydiff
+.. _pytest-astropy-header: https://github.com/astropy/pytest-astropy-header
+.. _pytest-filter-subpackage: https://github.com/astropy/pytest-filter-subpackage
+.. _pytest-mpl: https://github.com/matplotlib/pytest-mpl
+.. _pytest-cov: https://github.com/pytest-dev/pytest-cov
 .. _hypothesis: https://hypothesis.readthedocs.io
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,6 @@ The following dependencies are installed by this package:
   comparison of data arrays produced during unit tests
 * `pytest-filter-subpackage`_, a ``pytest`` plugin that adds a ``-P`` option to
   pytest to filter by sub-package.
-* `pytest-mpl`_, a ``pytest`` plugin used for pixel-by-pixel testing of images
-  generated from tests.
 * `pytest-cov`_, a ``pytest`` plugin to measure test coverage.
 * `hypothesis`_, a Python library for property based testing.
 
@@ -38,7 +36,6 @@ The following dependencies are installed by this package:
 .. _pytest-openfiles: https://github.com/astropy/pytest-openfiles
 .. _pytest-arraydiff: https://github.com/astropy/pytest-arraydiff
 .. _pytest-filter-subpackage: https://github.com/astropy/pytest-filter-subpackage
-.. _pytest-mpl: https://github.com/matplotlib/pytest-mpl
 .. _pytest-cov: https://github.com/pytest-dev/pytest-cov
 .. _hypothesis: https://hypothesis.readthedocs.io
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://astropy.org
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Framework :: Pytest
     Framework :: Hypothesis
     Intended Audience :: Developers
@@ -12,6 +12,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -37,5 +38,5 @@ install_requires =
     pytest-arraydiff>=0.1
     pytest-filter-subpackage>=0.1
     pytest-mpl>=0.11
-    pytest-cov
+    pytest-cov>=2.0
     hypothesis>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-astropy
-version = 0.6.0
+version = 0.8.0.dev
 url = https://astropy.org
 author = The Astropy Developers
 author_email = astropy.team@gmail.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
     pytest-astropy-header>=0.1.2
     pytest-arraydiff>=0.1
     pytest-filter-subpackage>=0.1
-    pytest-mpl>=0.11
     pytest-cov>=2.0
     hypothesis>=5.1
+    # We don't include the following for now since it brings in
+    # matplotlib as a dependency.
+    # pytest-mpl>=0.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-astropy
-url = https://astropy.org
+url = https://github.com/astropy/pytest-astropy
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
 classifiers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pytest-astropy
-version = 0.8.0.dev
 url = https://astropy.org
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
@@ -27,6 +26,7 @@ keywords = pytest, py.test, remotedata, openfiles, doctestplus
 zip_safe = False
 packages = find:
 python_requires = >=3.6
+setup_requires = setuptools_scm
 install_requires =
     pytest>=3.1.0
     pytest-doctestplus>=0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author_email = astropy.team@gmail.com
 classifiers =
     Development Status :: 3 - Alpha
     Framework :: Pytest
+    Framework :: Hypothesis
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -28,7 +29,7 @@ packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    pytest>=3.1.0
+    pytest>=4.6
     pytest-doctestplus>=0.2.0
     pytest-remotedata>=0.3.1
     pytest-openfiles>=0.3.1
@@ -37,4 +38,5 @@ install_requires =
     pytest-filter-subpackage>=0.1
     pytest-mpl>=0.11
     pytest-cov
-    hypothesis
+    # Bump hypothesis to >=5.0 in early Jan 2020
+    hypothesis>=4.53

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 license = BSD
 description = Meta-package containing dependencies for testing
 long_description = file: README.rst
-keywords = pytest, py.test, remotedata, openfiles, doctestplus
+keywords = pytest, remotedata, openfiles, doctestplus, hypothesis, property-based testing
 
 [options]
 zip_safe = False
@@ -38,5 +38,4 @@ install_requires =
     pytest-filter-subpackage>=0.1
     pytest-mpl>=0.11
     pytest-cov
-    # Bump hypothesis to >=5.0 in early Jan 2020
-    hypothesis>=4.53
+    hypothesis>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[metadata]
+name = pytest-astropy
+version = 0.6.0
+url = https://astropy.org
+author = The Astropy Developers
+author_email = astropy.team@gmail.com
+classifiers =
+    Development Status :: 3 - Alpha
+    Framework :: Pytest
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Software Development :: Testing
+    Topic :: Utilities
+license = BSD
+description = Meta-package containing dependencies for testing
+long_description = file: README.rst
+keywords = pytest, py.test, remotedata, openfiles, doctestplus
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.6
+install_requires =
+    pytest>=3.1.0
+    pytest-doctestplus>=0.2.0
+    pytest-remotedata>=0.3.1
+    pytest-openfiles>=0.3.1
+    pytest-astropy-header>=0.1.2
+    pytest-arraydiff>=0.1
+    pytest-filter-subpackage>=0.1
+    pytest-mpl>=0.11
+    pytest-cov
+    hypothesis

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,4 @@ if LooseVersion(setuptools.__version__) < LooseVersion('30.3.0'):
                      "later (found {0})".format(setuptools.__version__))
     sys.exit(1)
 
-setup()
+setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -1,55 +1,14 @@
 #!/usr/bin/env python
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- encoding: utf-8 -*-
 
+import sys
+import setuptools
+from distutils.version import LooseVersion
 from setuptools import setup
 
+# Setuptools 30.3.0 or later is needed for setup.cfg options to be used
+if LooseVersion(setuptools.__version__) < LooseVersion('30.3.0'):
+    sys.stderr.write("ERROR: pytest-astropy requires setuptools 30.3.0 or "
+                     "later (found {0})".format(setuptools.__version__))
+    sys.exit(1)
 
-def readme():
-    with open('README.rst') as ff:
-        return ff.read()
-
-
-setup(
-    name='pytest-astropy',
-    version='0.8.0.dev',
-    license='BSD',
-    description='Meta-package containing dependencies for testing',
-    long_description=readme(),
-    author='The Astropy Developers',
-    author_email='astropy.team@gmail.com',
-    url='https://astropy.org',
-    include_package_data=True,
-    zip_safe=False,
-    classifiers=[
-        # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 3 - Alpha',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development :: Testing',
-        'Topic :: Utilities',
-    ],
-    keywords=[ 'pytest', 'py.test', 'remotedata', 'openfiles', 'doctestplus' ],
-    python_requires='>=2.7',
-    install_requires=[
-        'pytest>=3.1.0',
-        'pytest-doctestplus>=0.2.0',
-        'pytest-remotedata>=0.3.1',
-        'pytest-openfiles>=0.3.1',
-        'pytest-astropy-header',
-        # Do not include as dependency until CI issues can be worked out
-        #'pytest-mpl',
-        'pytest-arraydiff>=0.1',
-        'hypothesis'
-    ]
-)
+setup()


### PR DESCRIPTION
This PR:

* adds [pytest-filter-subpackage](https://github.com/astropy/pytest-filter-subpackage)
* adds pytest-cov
* switches to use setup.cfg instead of setup.py to define most of the package metadata
* switches to using setuptools_scm
* drops support for Python 2.7 and 3.5
* incorporates the changes from https://github.com/astropy/pytest-astropy/pull/27