### PR TITLE
Pin attrs due to hypothesis requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     pytest-arraydiff>=0.1
     pytest-filter-subpackage>=0.1
     pytest-cov>=2.0
+    attrs>=19.2.0
     hypothesis>=5.1
     # We don't include the following for now since it brings in
     # matplotlib as a dependency.


### PR DESCRIPTION
We need to explicitly pin `attrs` to avoid this warning in downstream packages when an older `attrs` is present but not automatically updated (maybe due to a mix of `conda` and `pip` usage in the environment?):

```
hypothesis 5.1.5 has requirement attrs>=19.2.0, but you'll have attrs 18.2.0 which is incompatible
```

xref https://github.com/astropy/astropy/pull/9726#discussion_r367686568

cc @Zac-HD