### PR TITLE
Add pytest-mock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     pytest-arraydiff>=0.1
     pytest-filter-subpackage>=0.1
     pytest-cov>=2.0
+    pytest-mock>=2.0
     hypothesis>=5.1
     # We don't include the following for now since it brings in
     # matplotlib as a dependency.


### PR DESCRIPTION
I pinned it to 2.0 because it had some breaking changes in it (3.0 looks breaking as it dropped 2.7 support) but 2.0 was released in Jan, so might be too new?