### PR TITLE
Add a change log entry regarding pytest-cov

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Added ``pytest-mock`` as dependency. [#31]
 
+- Require ``pytest-cov`` 2.3.1 or later. [#41]
 
 0.8.0 (2020-01-16)
 ==================


### PR DESCRIPTION
The commit b4e9d55d3dc90cdf27f8289d7eef30f7f1db7e23 in #41 updated the minimum required `pytest-cov` version, but did not add a corresponding change log entry. This fixes that oversight.

#41 also updated the minimum version for `pytest-doctestplus`, but this pull request will not add a change log entry for that because the required version is about to be updated once more.