### PR TITLE
Update minimum required pytest-doctestplus version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 
 - Require ``pytest-cov`` 2.3.1 or later. [#41]
 
+- Require ``pytest-doctestplus`` 0.11.0 or later. [#43]
+
+- Dropped support for Python 3.6. [#43]
+
 0.8.0 (2020-01-16)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
@@ -27,11 +26,11 @@ keywords = pytest, remotedata, openfiles, doctestplus, hypothesis, property-base
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     pytest>=4.6
-    pytest-doctestplus>=0.9.0
+    pytest-doctestplus>=0.11.0
     pytest-remotedata>=0.3.1
     pytest-openfiles>=0.3.1
     pytest-astropy-header>=0.1.2


### PR DESCRIPTION
Because `astropy` is about to start using features introduced in
`pytest-doctestplus` 0.11.0, the minimum required version needs to be
updated. Furthermore, the minimum supported Python version for
`pytest-doctestplus` is 3.7 since astropy/pytest-doctestplus#159, which
means support for Python 3.6 must be dropped here too.