### PR TITLE
Add plugin for cpu/memory intensive tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ htmlcov
 
 # PyCharm
 .idea
+
+pytest_astropy/version.py
+pip-wheel-metadata/

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2021, Astropy Developers
+Copyright (c) 2011-2022, Astropy Developers
 
 All rights reserved.
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,12 @@ This is a meta-package that pulls in the dependencies that are used by
 `astropy`_ and some `affiliated packages`_ for testing. It can also be used for
 testing packages that are not affiliated with the Astropy project.
 
+This package also provides pytest markers for cpu and memory intensive tests
+(``pytest.mark.slow`` and ``pytest.mark.hugemem``). Tests marked with those
+markers are not run by default, can be run with the other tests with
+``--run-slow`` and ``--run-hugemem``, and can be run separately with ``-m slow``
+and ``-n hugemem``.
+
 .. _astropy: https://docs.astropy.org/en/latest/
 .. _affiliated packages: https://astropy.org/affiliated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ requires = ["setuptools>=30.3.0",
             "setuptools_scm",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+write_to = "pytest_astropy/version.py"

--- a/pytest_astropy/__init__.py
+++ b/pytest_astropy/__init__.py
@@ -1,0 +1,3 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from .version import version as __version__  # noqa

--- a/pytest_astropy/plugin.py
+++ b/pytest_astropy/plugin.py
@@ -1,5 +1,7 @@
-# Add a --runslow option to run slow tests
-# From https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Add a --run-slow and --run-hugemem options to run cpu and memory
+# intensive tests
 
 import pytest
 

--- a/pytest_astropy/plugin.py
+++ b/pytest_astropy/plugin.py
@@ -1,0 +1,39 @@
+# Add a --runslow option to run slow tests
+# From https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="run slow tests",
+    )
+    parser.addoption(
+        "--run-hugemem",
+        action="store_true",
+        default=False,
+        help="run memory intensive tests",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers",
+                            "hugemem: mark test as using a lot of memory")
+
+
+def pytest_collection_modifyitems(config, items):
+    run_slow = config.getoption("--run-slow")
+    run_hugemem = config.getoption("--run-hugemem")
+
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    skip_hugemem = pytest.mark.skip(reason="need --run-hugemem option to run")
+
+    for item in items:
+        if "slow" in item.keywords and not run_slow:
+            item.add_marker(skip_slow)
+        if "hugemem" in item.keywords and not run_hugemem:
+            item.add_marker(skip_hugemem)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,3 +44,7 @@ install_requires =
     # We don't include the following for now since it brings in
     # matplotlib as a dependency.
     # pytest-mpl>=0.11
+
+[options.entry_points]
+pytest11 =
+    pytest_astropy = pytest_astropy.plugin

--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,4 @@
 
 from setuptools import setup
 
-setup(use_scm_version=True)
+setup()


### PR DESCRIPTION
Related to https://github.com/astropy/astropy/pull/12350

With this plugin, cpu/memory intensive tests 
- are not run by default
- can be run with the other tests with `--run-slow` and `--run-hugemem`
- can be run separately with `-m slow` and `-n hugemem`

If you have better ideas for the marker names ... 