### PR TITLE
Require `pytest` 7.0 or later

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Dropped ``distutils`` as build dependency. [#47]
 
+- Require ``pytest`` 7.0 or later. [#49]
+
 0.9.0 (2021-09-21)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    pytest>=4.6
+    pytest>=7.0
     pytest-doctestplus>=0.11.0
     pytest-remotedata>=0.3.1
     pytest-openfiles>=0.3.1


### PR DESCRIPTION
Using older versions of `pytest` is not possible since astropy/astropy@7b98fa6d7a978b732dd80cd236d84611935fcea7 in astropy/astropy#12823.