### PR TITLE
fix hugemem parameter typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This package also provides pytest markers for cpu and memory intensive tests
 (``pytest.mark.slow`` and ``pytest.mark.hugemem``). Tests marked with those
 markers are not run by default, can be run with the other tests with
 ``--run-slow`` and ``--run-hugemem``, and can be run separately with ``-m slow``
-and ``-n hugemem``.
+and ``-m hugemem``.
 
 .. _astropy: https://docs.astropy.org/en/latest/
 .. _affiliated packages: https://astropy.org/affiliated


### PR DESCRIPTION
You select a pytest marker.
`-n` is reserved for the number of processes by pytest-xdist.