### PR TITLE
DEP: update lagging dependencies to match astropy dev's test requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,15 +33,16 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    pytest>=4.6
-    pytest-doctestplus>=1.0.0
+    pytest>=8.0.0
+    pytest-doctestplus>=1.4.0
     pytest-remotedata>=0.4.1
     pytest-astropy-header>=0.2.2
-    pytest-arraydiff>=0.5
-    pytest-filter-subpackage>=0.1.2
+    pytest-arraydiff>=0.5  # unused in astropy
+    pytest-filter-subpackage>=0.1.2 # documented, but not actively used in astropy
+    coverage>=7.2.0
     pytest-cov>=2.3.1
-    pytest-mock>=2.0
-    hypothesis>=5.1
+    pytest-mock>=2.0 # unused in astropy
+    hypothesis>=6.84.0
     # We don't include the following for now since it brings in
     # matplotlib as a dependency.
     # pytest-mpl>=0.11


### PR DESCRIPTION
Since I'm juggling with test dependencies these days, I thought I would upstream a couple of my findings.
This does 2 things:
- bump dependencies to match astropy's current requirements (some of which are not explicitly declared anywhere yet, but are in PRs)
- add comments for dependencies of this packages that are *not* currently used for astropy's own needs.


I don't know exactly what the scope of this metapackage entails. Should these unused dependencies be removed entirely, even at the risk of breaking any *other* consumers, or should they be left in place for backwards compat ?