### PR TITLE
DEP: add pytest-skip-slow as a dependency and remove redundant definitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 ===================
 
 - Minimum supported Python version is now 3.8. [#60]
+- ``slow`` and ``hugemem`` markers, and corresponding CLI flags ``--run-slow`` and
+  ``--run-hugemem``, are now defined by ``pytest-skip-slow``, which we now require
+  version 1.1.0 or later of. [#79]
 
 0.11.0 (2023-09-26)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@
 
 - Minimum supported Python version is now 3.8. [#60]
 - ``slow`` and ``hugemem`` markers, and corresponding CLI flags ``--run-slow`` and
-  ``--run-hugemem``, are now defined by ``pytest-skip-slow``, which we now require
-  version 1.1.0 or later of. [#79]
+  ``--run-hugemem``, are now defined by ``pytest-skip-slow``, which is pinned to
+  version 1.1.0. [#79]
 
 0.11.0 (2023-09-26)
 ===================

--- a/README.rst
+++ b/README.rst
@@ -10,12 +10,6 @@ This is a meta-package that pulls in the dependencies that are used by
 `astropy`_ and some `affiliated packages`_ for testing. It can also be used for
 testing packages that are not affiliated with the Astropy project.
 
-This package also provides pytest markers for cpu and memory intensive tests
-(``pytest.mark.slow`` and ``pytest.mark.hugemem``). Tests marked with those
-markers are not run by default, can be run with the other tests with
-``--run-slow`` and ``--run-hugemem``, and can be run separately with ``-m slow``
-and ``-m hugemem``.
-
 The package also provides the short option ``-R`` for ``--remote-data``.
 
 .. _astropy: https://docs.astropy.org/en/latest/
@@ -39,6 +33,8 @@ The following dependencies are installed by this package:
 * `pytest-mock`_,  a thin-wrapper around the mock package for easier use
   with ``pytest``.
 * `pytest-cov`_, a ``pytest`` plugin to measure test coverage.
+* `pytest-skip-slow`_, a ``pytest`` plugin to mark tests as slow or memory intensive,
+  and skip them by default.
 * `hypothesis`_, a Python library for property based testing.
 
 .. _pytest: https://doc.pytest.org
@@ -49,6 +45,7 @@ The following dependencies are installed by this package:
 .. _pytest-filter-subpackage: https://github.com/astropy/pytest-filter-subpackage
 .. _pytest-mock: https://github.com/pytest-dev/pytest-mock
 .. _pytest-cov: https://github.com/pytest-dev/pytest-cov
+.. _pytest-skip-slow: https://github.com/okken/pytest-skip-slow
 .. _hypothesis: https://hypothesis.readthedocs.io
 
 Installation

--- a/pytest_astropy/plugin.py
+++ b/pytest_astropy/plugin.py
@@ -1,45 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-# Add a --run-slow and --run-hugemem options to run cpu and memory
-# intensive tests
-
-import pytest
-
-
 def pytest_addoption(parser):
-    parser.addoption(
-        "--run-slow",
-        action="store_true",
-        default=False,
-        help="run slow tests",
-    )
-    parser.addoption(
-        "--run-hugemem",
-        action="store_true",
-        default=False,
-        help="run memory intensive tests",
-    )
     parser.addoption(
         "-R", nargs="?", const='any', default='none',
         help="run tests with online data, requires pytest-remotedata",
         dest="remote_data", choices=['astropy', 'any', 'github', 'none'])
-
-
-def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-    config.addinivalue_line("markers",
-                            "hugemem: mark test as using a lot of memory")
-
-
-def pytest_collection_modifyitems(config, items):
-    run_slow = config.getoption("--run-slow")
-    run_hugemem = config.getoption("--run-hugemem")
-
-    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
-    skip_hugemem = pytest.mark.skip(reason="need --run-hugemem option to run")
-
-    for item in items:
-        if "slow" in item.keywords and not run_slow:
-            item.add_marker(skip_slow)
-        if "hugemem" in item.keywords and not run_hugemem:
-            item.add_marker(skip_hugemem)

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     pytest-filter-subpackage>=0.1.2
     pytest-cov>=2.3.1
     pytest-mock>=2.0
+    pytest-skip-slow==1.1.0
     hypothesis>=5.1
     # We don't include the following for now since it brings in
     # matplotlib as a dependency.


### PR DESCRIPTION
close #73
companion to https://github.com/astropy/astropy/pull/18784
